### PR TITLE
Fix email validation on check endpoint

### DIFF
--- a/app/Http/Controllers/LeadController.php
+++ b/app/Http/Controllers/LeadController.php
@@ -78,9 +78,17 @@ final class LeadController extends Controller
      */
     public function checkEmail(Request $request, string $email): JsonResponse
     {
-        $request->validate([
-            'email' => 'email',
+        $validator = validator(['email' => $email], [
+            'email' => ['required', 'email:rfc'],
         ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Invalid email address.',
+                'errors' => $validator->errors()->get('email'),
+            ], 422);
+        }
 
         $lead = $this->leadService->getLeadByEmail($email);
 

--- a/tests/Feature/LeadApiTest.php
+++ b/tests/Feature/LeadApiTest.php
@@ -13,7 +13,7 @@ class LeadApiTest extends TestCase
     use RefreshDatabase;
 
     #[Test]
-    public function it_validates_email_on_check_endpoint(): void
+    public function itValidatesEmailOnCheckEndpoint(): void
     {
         $response = $this->getJson('/api/v1/leads/invalid-email/check');
 
@@ -24,4 +24,3 @@ class LeadApiTest extends TestCase
             ]);
     }
 }
-

--- a/tests/Feature/LeadApiTest.php
+++ b/tests/Feature/LeadApiTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class LeadApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_validates_email_on_check_endpoint(): void
+    {
+        $response = $this->getJson('/api/v1/leads/invalid-email/check');
+
+        $response->assertStatus(422)
+            ->assertJsonFragment([
+                'success' => false,
+                'message' => 'Invalid email address.',
+            ]);
+    }
+}
+


### PR DESCRIPTION
## Summary
- validate email path param in LeadController
- test email validation for /api/v1/leads/{email}/check endpoint

## Testing
- `npm test` *(fails: Network Error)*
- `./vendor/bin/phpunit --filter LeadApiTest` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e8c7a18d083329ea9f31c4f5be1b5