### PR TITLE
Fix GH Actions db env

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,6 +57,8 @@ jobs:
           # Add missing test environment variables
           echo "QUEUE_CONNECTION=sync" >> .env.testing
           echo "CACHE_DRIVER=array" >> .env.testing
+          # Create .env for commands that don't specify an environment
+          cp .env.testing .env
 
       - name: Generate application key
         run: php artisan key:generate --env=testing


### PR DESCRIPTION
## Summary
- ensure `php artisan` commands use the testing environment

## Testing
- `npm ci`
- `npm run test:coverage` *(fails: network errors)*

------
https://chatgpt.com/codex/tasks/task_e_686e918d8e08833299a2db9f8602a6ef