### PR TITLE
Require platform for all leads

### DIFF
--- a/app/DTOs/LeadDTO.php
+++ b/app/DTOs/LeadDTO.php
@@ -96,7 +96,7 @@ final class LeadDTO
      */
     public function requiresPlatform(): bool
     {
-        return $this->websiteType === WebsiteType::ECOMMERCE;
+        return true;
     }
 
     /**
@@ -148,8 +148,8 @@ final class LeadDTO
      */
     private function validatePlatformRequirement(): void
     {
-        if ($this->requiresPlatform() && $this->platform === null) {
-            throw new \InvalidArgumentException('Platform selection is required for e-commerce websites');
+        if ($this->platform === null) {
+            throw new \InvalidArgumentException('Platform selection is required');
         }
     }
 }

--- a/tests/Unit/LeadDTOTest.php
+++ b/tests/Unit/LeadDTOTest.php
@@ -40,7 +40,7 @@ class LeadDTOTest extends TestCase
             company: null,
             websiteUrl: null,
             websiteType: WebsiteType::BUSINESS,
-            platform: null
+            platform: 1
         );
 
         $this->assertEquals('John Doe', $dto->name);
@@ -48,7 +48,7 @@ class LeadDTOTest extends TestCase
         $this->assertNull($dto->company);
         $this->assertNull($dto->websiteUrl);
         $this->assertEquals(WebsiteType::BUSINESS, $dto->websiteType);
-        $this->assertNull($dto->platform);
+        $this->assertEquals(1, $dto->platform);
     }
 
     #[Test]
@@ -80,6 +80,7 @@ class LeadDTOTest extends TestCase
             'name' => 'John Doe',
             'email' => 'john@example.com',
             'website_type' => 'business',
+            'platform_id' => 1,
         ];
 
         $dto = LeadDTO::fromArray($data);
@@ -89,7 +90,7 @@ class LeadDTOTest extends TestCase
         $this->assertNull($dto->company);
         $this->assertNull($dto->websiteUrl);
         $this->assertEquals(WebsiteType::BUSINESS, $dto->websiteType);
-        $this->assertNull($dto->platform);
+        $this->assertEquals(1, $dto->platform);
     }
 
     #[Test]
@@ -125,7 +126,7 @@ class LeadDTOTest extends TestCase
             company: null,
             websiteUrl: null,
             websiteType: WebsiteType::BUSINESS,
-            platform: null
+            platform: 1
         );
 
         $array = $dto->toArray();
@@ -136,7 +137,7 @@ class LeadDTOTest extends TestCase
             'company' => null,
             'website_url' => null,
             'website_type' => 'business',
-            'platform_id' => null,
+            'platform_id' => 1,
         ], $array);
     }
 
@@ -158,7 +159,7 @@ class LeadDTOTest extends TestCase
                 company: null,
                 websiteUrl: null,
                 websiteType: $typeEnum,
-                platform: $typeEnum === WebsiteType::ECOMMERCE ? 1 : null
+                platform: 1
             );
 
             $array = $dto->toArray();
@@ -213,11 +214,11 @@ class LeadDTOTest extends TestCase
             company: null,
             websiteUrl: null,
             websiteType: WebsiteType::BLOG,
-            platform: null
+            platform: 1
         );
 
         $this->assertEquals(WebsiteType::BLOG, $dto->websiteType);
-        $this->assertNull($dto->platform);
+        $this->assertNotNull($dto->platform);
     }
 
     #[Test]
@@ -252,12 +253,12 @@ class LeadDTOTest extends TestCase
             company: null,
             websiteUrl: null,
             websiteType: WebsiteType::BUSINESS,
-            platform: null
+            platform: 1
         );
 
         $this->assertNull($dto->company);
         $this->assertNull($dto->websiteUrl);
-        $this->assertNull($dto->platform);
+        $this->assertEquals(1, $dto->platform);
     }
 
     #[Test]

--- a/tests/Unit/LeadServiceTest.php
+++ b/tests/Unit/LeadServiceTest.php
@@ -164,7 +164,7 @@ class LeadServiceTest extends TestCase
             company: null,
             websiteUrl: null,
             websiteType: WebsiteType::BUSINESS,
-            platform: null
+            platform: 1
         );
 
         $expectedLead = new Lead([
@@ -174,7 +174,7 @@ class LeadServiceTest extends TestCase
             'company' => null,
             'website_url' => null,
             'website_type' => 'business',
-            'platform_id' => null,
+            'platform_id' => 1,
             'created_at' => now(),
         ]);
         $expectedLead->id = 1;
@@ -196,7 +196,7 @@ class LeadServiceTest extends TestCase
                 return $data['lead_id'] === 1
                        && $data['email'] === 'john@example.com'
                        && $data['website_type'] === 'business'
-                       && $data['platform_id'] === null
+                       && $data['platform_id'] === 1
                        && isset($data['created_at']);
             }))
             ->once();
@@ -207,7 +207,7 @@ class LeadServiceTest extends TestCase
         $this->assertEquals('John Doe', $result->name);
         $this->assertEquals('john@example.com', $result->email);
         $this->assertEquals(WebsiteType::BUSINESS, $result->website_type);
-        $this->assertNull($result->platform_id);
+        $this->assertEquals(1, $result->platform_id);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary
- always require a platform when creating `LeadDTO`
- update validations
- adjust unit tests for new platform requirement

## Testing
- `phpunit` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686e9678c910833298041736de38747d